### PR TITLE
Removed child-drawer checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ export default class Drawer extends Component {
     initializeOpen: PropTypes.bool,
     open: PropTypes.bool,
     negotiatePan: PropTypes.bool,
+    onMoveStart: PropTypes.func,
     onClose: PropTypes.func,
     onCloseStart: PropTypes.func,
     onOpen: PropTypes.func,
@@ -97,6 +98,7 @@ export default class Drawer extends Component {
 
     styles: {},
     elevation: 0,
+    onMoveStart: () => {},
     onOpen: () => {},
     onClose: () => {},
     side: 'left',
@@ -275,6 +277,7 @@ export default class Drawer extends Component {
     this._length = length
 
     this.updatePosition()
+    this.props.onMoveStart()
     this._panning = true
   };
 

--- a/index.js
+++ b/index.js
@@ -110,14 +110,7 @@ export default class Drawer extends Component {
   getChildContext = () => ({ drawer: this });
   /*** END CONTEXT ***/
 
-  _registerChildDrawer(drawer) {
-    // Store child drawer for gesture disambiguation with multi drawer
-    // @TODO make cleaner, generalize to work with 3+ drawers, prop to disable/configure
-    this._childDrawer = drawer
-  }
-
   componentWillMount() {
-    if (this.context.drawer) this.context.drawer._registerChildDrawer(this)
     if (this.props.openDrawerThreshold && process.env.NODE_ENV !== 'production') console.error('react-native-drawer: openDrawerThreshold is obsolete. Use panThreshold instead.')
     if (this.props.panStartCompensation && process.env.NODE_ENV !== 'production') console.error('react-native-drawer: panStartCompensation is deprecated.')
     if (this.props.relativeDrag && process.env.NODE_ENV !== 'production') console.error('react-native-drawer: relativeDrag is deprecated.')
@@ -354,11 +347,6 @@ export default class Drawer extends Component {
 
   testPanResponderMask = (e, gestureState) => {
     if (this.props.disabled) return false
-
-    // Disable if parent or child drawer exist and are open
-    // @TODO make cleaner, generalize to work with 3+ drawers, prop to disable/configure
-    if (this.context.drawer && this.context.drawer._open) return false
-    if (this._childDrawer && this._childDrawer._open) return false
 
     let pos0 = this.isLeftOrRightSide() ? e.nativeEvent.pageX : e.nativeEvent.pageY
     let deltaOpen = this.isLeftOrTopSide() ? this.getDeviceLength() - pos0 : pos0


### PR DESCRIPTION
Hey, I was trying to use two nested drawers like this:
```js
<Drawer 
  content={
    <Drawer content={channels}>{menu}</Drawer>
  }
>
  {children}
</Drawer>
```

When user tries to close nested drawer, when the parent drawer is opened, removed checks prevented him from doing that. I dug into commits and issues related to this topic and it seems that those checks are optimized for nesting via children (not `content` prop):

```js
<Drawer content={menu}>
  <Drawer content={channels}>{children}</Drawer>
</Drawer>
```

Actually it's possible to implement required behavior using conditional values in `panCloseMask` and `panOpenMask` depending on `open` state of drawers, so those checks are not necessary. Please let me know if I missed anything here.