### PR TITLE
fixed drawer right margin increasing on iPhone X (#370)

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ export default class Drawer extends Component {
 
     switch (this.props.type) {
       case 'overlay':
-        drawerProps[this.props.side] = -this.getDeviceLength() + this._offsetOpen + this._length
+        drawerProps[this.props.side] = Math.round(-this.getDeviceLength() + this._offsetOpen + this._length)
         mainProps[this.props.side] = this._offsetClosed
         break
       case 'static':


### PR DESCRIPTION
just added rounding from https://github.com/root-two/react-native-drawer/pull/352#issuecomment-389238360
it works fine with simulator iPhone XS/XS MAX
related issues https://github.com/root-two/react-native-drawer/issues/370